### PR TITLE
straight-up integer depth parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For universe-polymorphic constants, you can turn on printing universe instances:
 
 You can change the depth at which the plugin prints definitions:
 
-    Coq < PrintAST le with depth "2".
+    Coq < PrintAST le with depth 2.
     (Ind ((Name le) (inductive_body (le_n 1 (Prod (Name n) (Ind ((Name nat) (inductive_body (O 1 (Var nat)) (S 2 (Prod (Anonymous) (Var nat) (Var nat)))))) (App (Var le) (Var n) (Var n)))) (le_S 2 (Prod (Name n) (Ind ((Name nat) (inductive_body (O 1 (Var nat)) (S 2 (Prod (Anonymous) (Var nat) (Var nat)))))) (Prod (Name m) (Ind ((Name nat) (inductive_body (O 1 (Var nat)) (S 2 (Prod (Anonymous) (Var nat) (Var nat)))))) (Prod (Anonymous) (App (Var le) (Var n) (Var m)) (App (Var le) (Var n) (App (Construct (Ind ((Name nat) (inductive_body (O 1 (Var nat)) (S 2 (Prod (Anonymous) (Var nat) (Var nat)))))) 2) (Var m))))))))))
 
 # The Fun Part

--- a/plugin/src/ast_plugin.ml4
+++ b/plugin/src/ast_plugin.ml4
@@ -654,7 +654,7 @@ let print_ast (depth : int) (def : Constrexpr.constr_expr) =
 VERNAC COMMAND EXTEND Print_AST
 | [ "PrintAST" constr(def) ] ->
   [ print_ast 1 def ]
-| [ "PrintAST" constr(def) "with" "depth" string(depth)] ->
-  [ print_ast (int_of_string depth) def ]
+| [ "PrintAST" constr(def) "with" "depth" integer(depth)] ->
+  [ print_ast depth def ]
 END
 


### PR DESCRIPTION
They renamed that to`int(...)` in 8.6.