### PR TITLE
Fix build issue with Coq v8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For example:
 
 ## Using the Plugin
 
-The plugin is built to work with Coq 8.8. It may not build for other versions of Coq, since the
+The plugin is built to work with Coq 8.9. It may not build for other versions of Coq, since the
 API sometimes changes between Coq versions.
 
 To build:

--- a/plugin/src/ast_plugin.ml4
+++ b/plugin/src/ast_plugin.ml4
@@ -247,9 +247,10 @@ let build_universe_instance (i : Instance.t) =
  * Build the AST for a sort
  *)
 let build_sort (s : Sorts.t) =
-  let s_ast =
+  let s_ast = let open Sorts in
     match s with
-    | Prop _ -> if s = Sorts.prop then "Prop" else "Set"
+    | Prop -> "Prop"
+    | Set -> "Set"
     | Type u -> build "Type" [build_universe u]
   in build "Sort" [s_ast]
 
@@ -436,7 +437,7 @@ let build_cofix (funs : string list) (index : int) =
 (*
  * Get the body of a mutually inductive type
  *)
-let lookup_mutind_body (i : mutual_inductive) (env : env) =
+let lookup_mutind_body (i : MutInd.t) (env : env) =
   lookup_mind i env
 
 (*


### PR DESCRIPTION
Fixes #4

This fix doesn't build on Coq v8.8 due to an incompatible API change.